### PR TITLE
Update for Ansible 2.0

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,15 +4,15 @@ galaxy_info:
   description: Install Ruby with Brightbox PPA
   company: RoleModel
   license: MIT
-  min_ansible_version: 1.4
+  min_ansible_version: 1.9
 
   platforms:
     - name: Ubuntu
       versions:
         - precise
+        - trusty
   categories:
     - system
     - development
 
-version: 1.0.0
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,27 +1,27 @@
 ---
 - name: ppa dependencies
-  sudo: yes
   apt: name={{item}} update_cache=yes cache_valid_time=300
   with_items:
     - python-software-properties
+  become: yes
 
 - name: brightbox ruby repo
-  sudo: yes
   apt_repository: repo=ppa:brightbox/ruby-ng update_cache=yes
+  become: yes
 
 - name: install ruby packages
-  sudo: yes
   apt: name={{item}} state=latest
   with_items:
     - ruby-switch
     - "{{brightbox_ruby_version}}"
     - "{{brightbox_ruby_version}}-dev"
+  become: yes
 
 - name: switch to {{brightbox_ruby_version}}
-  sudo: yes
   shell: ruby-switch --set {{brightbox_ruby_version}}
+  become: yes
 
 - name: install default gems
-  sudo: yes
   command: gem install {{item}} --no-document
   with_items: brightbox_ruby_default_gems
+  become: yes


### PR DESCRIPTION
Resolve 2.0 deprecation warnings by using `become` instead of `sudo`.
`version` meta var is not supported by Ansible 2.0.
