### PR TITLE
Update ruby version regex for Ansible 2.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ruby_version: 2.2.2
-brightbox_ruby_version: ruby{{ ruby_version | regex_replace('^(\d\.\d)\..*$', '\\1') }}
+brightbox_ruby_version: ruby{{ ruby_version | regex_replace('^(\d\.\d)\..*$', '\1') }}
 brightbox_ruby_default_gems:
   - bundler


### PR DESCRIPTION
Ansible changed its regex parsing after 1.9 to make things easier. The upshot is that you don't need to escape as much as you did before. This change brings the Ruby version regex up to 2.0 standard, but is still backward compatible with 1.9 (tested).
